### PR TITLE
test Зябликов Дмитрий

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -851,12 +851,12 @@
             "version": "v2.6.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/doctrine/doctrine2.git",
+                "url": "https://github.com/doctrine/orm.git",
                 "reference": "87ee409783a4a322b5597ebaae558661404055a7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/doctrine2/zipball/87ee409783a4a322b5597ebaae558661404055a7",
+                "url": "https://api.github.com/repos/doctrine/orm/zipball/87ee409783a4a322b5597ebaae558661404055a7",
                 "reference": "87ee409783a4a322b5597ebaae558661404055a7",
                 "shasum": ""
             },
@@ -1858,16 +1858,16 @@
         },
         {
             "name": "symfony/flex",
-            "version": "v1.0.80",
+            "version": "v1.1.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/flex.git",
-                "reference": "729aee08d62b47224e85b83c97e2824ff7d1735e"
+                "reference": "955774ecf07b10230bb5b44e150ba078b45f68fa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/flex/zipball/729aee08d62b47224e85b83c97e2824ff7d1735e",
-                "reference": "729aee08d62b47224e85b83c97e2824ff7d1735e",
+                "url": "https://api.github.com/repos/symfony/flex/zipball/955774ecf07b10230bb5b44e150ba078b45f68fa",
+                "reference": "955774ecf07b10230bb5b44e150ba078b45f68fa",
                 "shasum": ""
             },
             "require": {
@@ -1881,7 +1881,7 @@
             "type": "composer-plugin",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0-dev"
+                    "dev-master": "1.1-dev"
                 },
                 "class": "Symfony\\Flex\\Flex"
             },
@@ -1900,7 +1900,8 @@
                     "email": "fabien.potencier@gmail.com"
                 }
             ],
-            "time": "2018-05-02T19:08:56+00:00"
+            "description": "Composer plugin for Symfony",
+            "time": "2018-11-15T06:11:38+00:00"
         },
         {
             "name": "symfony/framework-bundle",
@@ -2164,12 +2165,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/lts.git",
-                "reference": "6de50b244bad631a71544b3cc3c8e206c0e5f991"
+                "reference": "c1affae45b78aee036effa1759237e7fa96d4af2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/lts/zipball/6de50b244bad631a71544b3cc3c8e206c0e5f991",
-                "reference": "6de50b244bad631a71544b3cc3c8e206c0e5f991",
+                "url": "https://api.github.com/repos/symfony/lts/zipball/c1affae45b78aee036effa1759237e7fa96d4af2",
+                "reference": "c1affae45b78aee036effa1759237e7fa96d4af2",
                 "shasum": ""
             },
             "conflict": {
@@ -2249,7 +2250,8 @@
             ],
             "description": "Enforces Long Term Supported versions of Symfony components",
             "homepage": "https://symfony.com",
-            "time": "2018-04-03T05:04:16+00:00"
+            "abandoned": "symfony/flex",
+            "time": "2018-10-03T12:03:19+00:00"
         },
         {
             "name": "symfony/orm-pack",

--- a/config/routes.yaml
+++ b/config/routes.yaml
@@ -1,11 +1,10 @@
 showTodos:
-  path: /
+  path: /{all}/{id}
   controller: App\Controller\TodosController::showTodos
+  defaults:
+    all: 0
+    id: 0
 
-completeTodo:
-  path: /complete
-  controller: App\Controller\TodosController::completeTodo
-
-uncompleteTodo:
-  path: /uncomplete
-  controller: App\Controller\TodosController::uncompleteTodo
+updateTodo:
+  path: /update/{id}/completed/{completed}
+  controller: App\Controller\TodosController::updateTodo

--- a/src/Controller/TodosController.php
+++ b/src/Controller/TodosController.php
@@ -2,32 +2,32 @@
 
 namespace App\Controller;
 
-use Doctrine\DBAL\Connection;
+use App\Entity\Todos;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 
 class TodosController extends AbstractController
 {
-    public function showTodos(Connection $connection)
+    public function showTodos($all)
     {
-        if (isset($_GET['all']) && $_GET['all'] == '1') {
-            $todos = $connection->fetchAll('SELECT t.* FROM todos t');
-        } else {
-            $todos = $connection->fetchAll('SELECT t.* FROM todos t WHERE completed = 0');
-        }
+        $entityManager = $this->getDoctrine()->getManager();
+        $repository = $entityManager->getRepository(Todos::class);
+
+        (int)$all === 1
+            ? $todos = $repository->findAll()
+            : $todos = $repository->findBy(
+                ['completed' => 0]
+            );
 
         return $this->render('showTodos.html.twig', ['todos' => $todos]);
     }
 
-    public function completeTodo(Connection $connection)
+    public function updateTodo($id, $completed)
     {
-        $connection->executeQuery('UPDATE todos SET completed = 1 WHERE id = ' . $_GET['id']);
+        (int)$completed === 0 ? $completed = 1 : $completed = 0;
 
-        return $this->redirect('/');
-    }
-
-    public function uncompleteTodo(Connection $connection)
-    {
-        $connection->executeQuery('UPDATE todos SET completed = 0 WHERE id = ' . $_GET['id']);
+        $this->getDoctrine()->getManager()
+        ->getRepository(Todos::class)
+            ->updateById($id, $completed);
 
         return $this->redirect('/');
     }

--- a/src/Entity/Todos.php
+++ b/src/Entity/Todos.php
@@ -1,0 +1,69 @@
+<?php
+
+
+namespace App\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity(repositoryClass="App\Repository\TodosRepository")
+ */
+class Todos
+{
+    /**
+     * @ORM\Id
+     * @ORM\GeneratedValue
+     * @ORM\Column(type="integer")
+     */
+    public $id;
+
+    /**
+     * @ORM\Column(type="string", length=255)
+     */
+    public $text;
+
+    /**
+     * @ORM\Column(type="boolean")
+     */
+    public $completed;
+
+
+    /**
+     * @return mixed
+     */
+    public function getText()
+    {
+        return $this->text;
+    }
+
+    /**
+     * @param mixed $text
+     */
+    public function setText($text): void
+    {
+        $this->text = $text;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getCompleted()
+    {
+        return $this->completed;
+    }
+
+    /**
+     * @param mixed $completed
+     */
+    public function setCompleted($completed): void
+    {
+        $this->completed = $completed;
+    }
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+
+}

--- a/src/Repository/TodosRepository.php
+++ b/src/Repository/TodosRepository.php
@@ -1,0 +1,35 @@
+<?php
+
+
+namespace App\Repository;
+
+use App\Entity\Todos;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Symfony\Bridge\Doctrine\RegistryInterface;
+
+
+class TodosRepository extends ServiceEntityRepository
+{
+    public function __construct(RegistryInterface $registry)
+    {
+        parent::__construct($registry, Todos::class);
+    }
+
+    public function updateById($id, $completed)
+    {
+        // automatically knows to select Products
+        // the "p" is an alias you'll use in the rest of the query
+        $qb = $this->createQueryBuilder('t')
+            ->update()
+            ->set('t.completed', ':completed')
+            ->setParameter('completed', $completed)
+            ->where('t.id = :id')
+            ->setParameter('id', $id)
+            ->getQuery();
+
+        return $qb->execute();
+
+        // to get just one result:
+        // $product = $qb->setMaxResults(1)->getOneOrNullResult();
+    }
+}

--- a/templates/showTodos.html.twig
+++ b/templates/showTodos.html.twig
@@ -6,13 +6,13 @@
     </head>
     <body>
         <h1>Todo</h1>
-        <p><a href="{{ path('showTodos') }}?all=1">Show completed</a></p>
+        <p><a href="{{ path('showTodos', {"all": 1 }) }}">Show completed</a></p>
         <ul>
             {% for todo in todos %}
                 {% if todo.completed %}
-                    <li><s>{{ todo.text }}</s> | <a href="{{ path('uncompleteTodo') }}?id={{ todo.id }}">Reset</a></li>
+                    <li><s>{{ todo.text }}</s> | <a href="{{ path('updateTodo', {"id": todo.id, "completed": todo.completed }) }}">Reset</a></li>
                 {% else %}
-                    <li>{{ todo.text }} | <a href="{{ path('completeTodo') }}?id={{ todo.id }}">Complete</a></li>
+                    <li>{{ todo.text }} | <a href="{{ path('updateTodo', {"id": todo.id, "completed": todo.completed }) }}">Complete</a></li>
                 {% endif %}
             {% endfor %}
         </ul>


### PR DESCRIPTION
1 Убрал использование GET параметров. Теперь url стали красивее для пользователя. 
2 Вместо сырых sql запросов использовал doctrine ORM и qweryBulder.
3  Объединил два роута в один updateTodo чтобы не дублировать код. В этом методе использовал именно qweryBulder для метода UPDATE, что бы избежать дополнительного SELECT при использовании  doctrine ORM. 
4 В контроллере оставил 2 метода show и updateTodo для лучшей читабельности кода. Эти два метода так же возможно объединить в один, тогда можно было бы использовать только doctrine ORM без дополнительного SELECT в БД.
5 В миграциях оставил сырой SQL так как миграции автоматически генерируются в нём, на основании Entity. Думаю это удобно.